### PR TITLE
Add profiling CLI flag and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ An improvement of this code is also available: the [Progressive ESO (PESO)](http
 
 It is meant to be used with the [Parallel computing toolbox of Matlab](https://fr.mathworks.com/products/parallel-computing.html) on multi-core processors. The code itself solves a Finite Difference approximation of the heat equation on unspecified shapes with a direct sparse solver. The test case converges in about one day on a desktop computer with 8 cores.
 
+## Usage
+
+Run the Python implementation with:
+
+```bash
+python eso.py
+```
+
+To generate profiling statistics use the `--profile` flag:
+
+```bash
+python eso.py --profile
+```
+
+This writes timing information to `eso_profile.prof` which can be
+inspected later with tools such as `pstats`.
+
 ## Test case
 ![test case](/Pictures/Test_case.png)
 

--- a/eso.py
+++ b/eso.py
@@ -271,4 +271,15 @@ def run_eso_method():
 
 
 if __name__ == '__main__':
-    run_eso_method()
+    import argparse
+    import cProfile
+
+    parser = argparse.ArgumentParser(description='Run the ESO demo')
+    parser.add_argument('--profile', action='store_true',
+                        help='run the algorithm under cProfile')
+    args = parser.parse_args()
+
+    if args.profile:
+        cProfile.run('run_eso_method()', 'eso_profile.prof')
+    else:
+        run_eso_method()


### PR DESCRIPTION
## Summary
- add optional `--profile` flag in `eso.py` that runs the solver under `cProfile`
- document how to use the new flag in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python eso.py --profile` *(fails: KeyboardInterrupt during long run)*

------
https://chatgpt.com/codex/tasks/task_e_6863d14e215c8324b80d8e2855fd01e0