### PR TITLE
Save iteration images for gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ python eso.py --profile
 This writes timing information to `eso_profile.prof` which can be
 inspected later with tools such as `pstats`.
 
+During execution, each iteration is also saved as an image in a
+subdirectory of `Pictures`. The directory name includes the conductivity
+ratio, filling ratio and image size so it can easily be used to build a
+GIF afterwards.
+
 ## Test case
 ![test case](/Pictures/Test_case.png)
 

--- a/eso.py
+++ b/eso.py
@@ -272,6 +272,12 @@ def run_eso_method(max_iterations=None):
     history_map = np.zeros((height, width))
     history_map[0, 0] = 1
 
+    frames_dir = os.path.join(
+        "Pictures",
+        f"frames_kp{high_conductivity}_phi{filling_ratio}_{width}x{height}",
+    )
+    os.makedirs(frames_dir, exist_ok=True)
+
     rgb = initial_bc[:, :, :3]
     mask_white = np.all(rgb == 255, axis=2)
     mask_gray = np.all(rgb == 127, axis=2)
@@ -317,6 +323,12 @@ def run_eso_method(max_iterations=None):
             os.path.join(
                 "Figure",
                 f"Figure_kp_ko_{high_conductivity}_phi_{filling_ratio}_{m:06d}.png",
+            )
+        )
+        fig.savefig(
+            os.path.join(
+                frames_dir,
+                f"frame_{m:06d}.png",
             )
         )
         Image.fromarray((display_data * 255).astype(np.uint8)).save(


### PR DESCRIPTION
## Summary
- capture every iteration into `Pictures/frames_kp<kp>_phi<phi>_<width>x<height>`
- document where iteration images are stored

## Testing
- `python -m py_compile eso.py`
- `python eso.py --max-iterations 1`

------
https://chatgpt.com/codex/tasks/task_e_6863eacddb4c832491b2804aa49dac01